### PR TITLE
Added a fully working CLI.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,50 +1,5 @@
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-{-# LANGUAGE LambdaCase #-}
 module Main where
-import Language.Goose.Parser.Parser
-import Language.Goose.Module.Resolver
-import Language.Goose.Module.Bundler
-import Language.Goose.Typecheck.Checker
-import Language.Goose.Transformation.ANF.ANF
-import Language.Goose.Transformation.Closure.Conversion
-import Language.Goose.Transformation.EtaExpansion
-import Language.Goose.Transformation.DeclarationRemover
-import Language.Goose.LLVM.BuildLibrary (buildExecutable)
-import System.Environment
-import Data.List
-
-import qualified Log.Error as L
-
-
-chunkBy2 :: [a] -> [(a, a)]
-chunkBy2 [] = []
-chunkBy2 (x:y:xs) = (x, y) : chunkBy2 xs
-chunkBy2 _ = error "chunkBy2: odd number of elements"
+import CLI.CLI (runCLI)
 
 main :: IO ()
-main = do
-  getArgs >>= \case
-    file:libraries -> do
-      content <- readFile file
-      ast <- parseGoose file content
-      case ast of
-        Left err -> L.printParseError err file content
-        Right ast' -> do
-          ast <- runModuleResolver file ast'
-          case ast of
-            Left err -> L.printError (fst err, Nothing, snd err) "Module resolution"
-            Right ast' -> do
-              ast <- runModuleBundling $ nub ast'
-              case ast of
-                Left err -> L.printError (fst err, Nothing, snd err) "Module bundling"
-                Right ast' -> do
-                  ast <- performInfer $ nub ast'
-                  case ast of
-                    Left err -> L.printError err "Type inference"
-                    Right ast' -> do
-                      ast <- return $ runEtaExpansion ast'
-                      ast <- runANF ast
-                      ast <- return $ runClosureConversion ast
-                      ast <- return $ addInitFunction ast
-                      buildExecutable ast libraries
-    _ -> putStrLn "Usage: goose <file> [libraries]"
+main = runCLI

--- a/goose.cabal
+++ b/goose.cabal
@@ -62,6 +62,9 @@ library
     exposed-modules:
         Log.Error
 
+        CLI.CLI
+        CLI.Phases
+
         Language.Goose.CST.Annoted
         Language.Goose.CST.Located
         Language.Goose.CST.Literal
@@ -134,7 +137,7 @@ library
       , llvm-hs
       , llvm-hs-pure
       , bytestring
-      , int-cast
+      , optparse-applicative
 
     -- Directories containing source files.
     hs-source-dirs:   src

--- a/goose.cabal
+++ b/goose.cabal
@@ -64,6 +64,7 @@ library
 
         CLI.CLI
         CLI.Phases
+        CLI.REPL
 
         Language.Goose.CST.Annoted
         Language.Goose.CST.Located
@@ -138,6 +139,7 @@ library
       , llvm-hs-pure
       , bytestring
       , optparse-applicative
+      , temporary
 
     -- Directories containing source files.
     hs-source-dirs:   src

--- a/goose.cabal
+++ b/goose.cabal
@@ -140,6 +140,8 @@ library
       , bytestring
       , optparse-applicative
       , temporary
+      , repline
+      , haskeline
 
     -- Directories containing source files.
     hs-source-dirs:   src

--- a/src/CLI/CLI.hs
+++ b/src/CLI/CLI.hs
@@ -1,0 +1,70 @@
+module CLI.CLI where
+
+import Options.Applicative
+import System.Info
+import System.Directory.Internal.Prelude (exitFailure)
+import System.Directory (doesFileExist)
+import CLI.Phases (compileFromString)
+
+data CLI =
+    Compile
+      { input     :: String
+      , libraries :: String
+      , flags     :: String
+      , output    :: String}
+  | Run
+      { input     :: String
+      , libraries :: String }
+  | Repl
+      { libraries :: String }
+  deriving Show
+
+splitOnSep :: String -> Char -> [String]
+splitOnSep [] _ = []
+splitOnSep (x:xs) sep
+  | x == sep = splitOnSep xs sep
+  | otherwise = let (word, rest) = break (== sep) (x:xs) in word : splitOnSep rest sep
+
+runCLI :: IO ()
+runCLI = do
+  cli <- customExecParser p opts
+  case cli of
+    Compile input libraries flags output -> do
+      exists <- doesFileExist input
+      if exists
+        then do
+          content <- readFile input
+          compileFromString content input (splitOnSep libraries ',') (splitOnSep flags ',') output
+        else putStrLn "File does not exist" *> exitFailure
+    Run input libraries -> do
+      putStrLn "Run"
+      putStrLn $ "Input: " ++ input
+      putStrLn $ "Libraries: " ++ show (splitOnSep libraries ',')
+    Repl libraries -> do
+      putStrLn "Repl"
+      putStrLn $ "Libraries: " ++ show (splitOnSep libraries ',')
+  where
+    opts = info (cli <**> helper)
+      ( fullDesc
+     <> header "Goose compiler" )
+    p = prefs showHelpOnEmpty
+
+cli :: Parser CLI
+cli = subparser
+  ( command "compile" (info compiler (progDesc "Compile a Goose program")) )
+
+compiler :: Parser CLI
+compiler = Compile
+  <$> argument str (metavar "INPUT")
+  <*> strOption (long "includes" <> short 'i' <> metavar "LIBRARIES" <> help "Libraries to link" <> value "")
+  <*> strOption (long "libraries" <> short 'l' <> metavar "LINK LIBRARIES" <> help "Libraries when linking" <> value "")
+  <*> strOption (long "output" <> short 'o' <> metavar "OUTPUT" <> help "Output file" <> if os == "mingw32" then value "a.exe" else value "a.out")
+
+runner :: Parser CLI
+runner = Run
+  <$> argument str (metavar "INPUT")
+  <*> strOption (long "includes" <> short 'i' <> metavar "LIBRARY" <> help "Library to link")
+
+repl :: Parser CLI
+repl = Repl
+  <$> strOption (long "includes" <> short 'i' <> metavar "LIBRARY" <> help "Library to link")

--- a/src/CLI/CLI.hs
+++ b/src/CLI/CLI.hs
@@ -5,6 +5,7 @@ import System.Info
 import System.Directory.Internal.Prelude (exitFailure)
 import System.Directory (doesFileExist)
 import CLI.Phases (compileFromString)
+import CLI.REPL (runREPL)
 
 data CLI =
     Compile
@@ -40,9 +41,7 @@ runCLI = do
       putStrLn "Run"
       putStrLn $ "Input: " ++ input
       putStrLn $ "Libraries: " ++ show (splitOnSep libraries ',')
-    Repl libraries -> do
-      putStrLn "Repl"
-      putStrLn $ "Libraries: " ++ show (splitOnSep libraries ',')
+    Repl libraries -> runREPL [] (splitOnSep libraries ',')
   where
     opts = info (cli <**> helper)
       ( fullDesc
@@ -51,7 +50,9 @@ runCLI = do
 
 cli :: Parser CLI
 cli = subparser
-  ( command "compile" (info compiler (progDesc "Compile a Goose program")) )
+  ( command "compile" (info compiler (progDesc "Compile a file"))
+ <> command "run" (info runner (progDesc "Run a file"))
+ <> command "repl" (info repl (progDesc "Run the REPL")) )
 
 compiler :: Parser CLI
 compiler = Compile
@@ -63,8 +64,8 @@ compiler = Compile
 runner :: Parser CLI
 runner = Run
   <$> argument str (metavar "INPUT")
-  <*> strOption (long "includes" <> short 'i' <> metavar "LIBRARY" <> help "Library to link")
+  <*> strOption (long "includes" <> short 'i' <> metavar "LIBRARY" <> help "Library to link" <> value "")
 
 repl :: Parser CLI
 repl = Repl
-  <$> strOption (long "includes" <> short 'i' <> metavar "LIBRARY" <> help "Library to link")
+  <$> strOption (long "includes" <> short 'i' <> metavar "LIBRARY" <> help "Library to link" <> value "")

--- a/src/CLI/Phases.hs
+++ b/src/CLI/Phases.hs
@@ -1,0 +1,38 @@
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+module CLI.Phases where
+import Language.Goose.Parser.Parser
+import Language.Goose.Module.Resolver
+import Language.Goose.Module.Bundler
+import Language.Goose.Typecheck.Checker
+import Language.Goose.Transformation.ANF.ANF
+import Language.Goose.Transformation.Closure.Conversion
+import Language.Goose.Transformation.EtaExpansion
+import Language.Goose.Transformation.DeclarationRemover
+import Language.Goose.LLVM.BuildLibrary (buildExecutable)
+import Data.List
+
+import qualified Log.Error as L
+
+compileFromString :: String -> FilePath -> [String] -> [String] -> String -> IO ()
+compileFromString input filename libraries flags output = do
+  ast <- parseGoose filename input
+  case ast of
+    Left err -> L.printParseError err filename input
+    Right ast' -> do
+      ast <- runModuleResolver filename ast'
+      case ast of
+        Left err -> L.printError (fst err, Nothing, snd err) "Module resolution"
+        Right ast' -> do
+          ast <- runModuleBundling $ nub ast'
+          case ast of
+            Left err -> L.printError (fst err, Nothing, snd err) "Module bundling"
+            Right ast' -> do
+              ast <- performInfer $ nub ast'
+              case ast of
+                Left err -> L.printError err "Type inference"
+                Right ast' -> do
+                  ast <- return $ runEtaExpansion ast'
+                  ast <- runANF ast
+                  ast <- return $ runClosureConversion ast
+                  ast <- return $ addInitFunction ast
+                  buildExecutable ast libraries flags output

--- a/src/CLI/Phases.hs
+++ b/src/CLI/Phases.hs
@@ -12,6 +12,10 @@ import Language.Goose.LLVM.BuildLibrary (buildExecutable)
 import Data.List
 
 import qualified Log.Error as L
+import Data.Functor
+import Language.Goose.Transformation.ANF.AST (ANFDefinition)
+import Language.Goose.CST.Located (Located)
+import Language.Goose.CST.Expression (Toplevel)
 
 compileFromString :: String -> FilePath -> [String] -> [String] -> String -> IO ()
 compileFromString input filename libraries flags output = do
@@ -21,18 +25,38 @@ compileFromString input filename libraries flags output = do
     Right ast' -> do
       ast <- runModuleResolver filename ast'
       case ast of
-        Left err -> L.printError (fst err, Nothing, snd err) "Module resolution"
+        Left err -> L.printError Nothing (fst err, Nothing, snd err) "Module resolution"
         Right ast' -> do
           ast <- runModuleBundling $ nub ast'
           case ast of
-            Left err -> L.printError (fst err, Nothing, snd err) "Module bundling"
+            Left err -> L.printError Nothing (fst err, Nothing, snd err) "Module bundling"
             Right ast' -> do
               ast <- performInfer $ nub ast'
               case ast of
-                Left err -> L.printError err "Type inference"
+                Left err -> L.printError Nothing err "Type inference"
                 Right ast' -> do
                   ast <- return $ runEtaExpansion ast'
                   ast <- runANF ast
                   ast <- return $ runClosureConversion ast
                   ast <- return $ addInitFunction ast
                   buildExecutable ast libraries flags output
+
+getANFDefinitions :: String -> [Located Toplevel] -> String -> IO (Maybe [ANFDefinition])
+getANFDefinitions content ast' filename = do
+  ast <- runModuleResolver filename ast'
+  case ast of
+    Left err -> L.printError (Just content) (fst err, Nothing, snd err) "Module resolution" $> Nothing
+    Right ast' -> do
+      ast <- runModuleBundling $ nub ast'
+      case ast of
+        Left err -> L.printError (Just content) (fst err, Nothing, snd err) "Module bundling" $> Nothing
+        Right ast' -> do
+          ast <- performInfer $ nub ast'
+          case ast of
+            Left err -> L.printError (Just content) err "Type inference" $> Nothing
+            Right ast' -> do
+              ast <- return $ runEtaExpansion ast'
+              ast <- runANF ast
+              ast <- return $ runClosureConversion ast
+              return . Just $ addInitFunction ast
+                

--- a/src/CLI/REPL.hs
+++ b/src/CLI/REPL.hs
@@ -1,48 +1,110 @@
+{-# LANGUAGE FlexibleContexts #-}
 module CLI.REPL where
-
-import Language.Goose.Parser.Parser
+import Language.Goose.Parser.Parser ( parseExpression, runGoose )
 import Language.Goose.CST.Expression (Toplevel (Function), Expression (Sequence, Let))
 import Language.Goose.CST.Located (Located)
 import Language.Goose.Parser.Modules.Toplevel (parseToplevel)
-import Language.Goose.Parser.Lexer (parseEither)
+import Language.Goose.Parser.Lexer (parseEither, reservedWords)
 import qualified Text.Parsec as P
 import Text.Parsec (ParseError)
-import System.IO (hFlush, stdout, hSetBuffering, BufferMode (NoBuffering))
 import CLI.Phases (getANFDefinitions)
 import qualified Language.Goose.CST.Located as C
 import qualified Language.Goose.CST.Annoted as C
 import Language.Goose.LLVM.BuildLibrary (buildAndRun)
-import Control.Monad (forM_)
 import qualified Log.Error as L
+import System.Console.Repline
+import Control.Monad.State
+import qualified Control.Monad.RWS as ST
+import Data.List (isPrefixOf)
 
 runParserREPL :: Monad m => String -> m (Either ParseError (Either (Located Expression) (Located Toplevel)))
 runParserREPL input = runGoose "REPL" input $ parseEither (parseExpression <* P.eof) (parseToplevel parseExpression)
 
-runREPL :: [Located Toplevel] -> [String] -> IO ()
-runREPL ast libraries = do
-  hSetBuffering stdout NoBuffering
-  putStr "goose> "
-  input <- getLine
-  case input of
-    ":q" -> return ()
-    [] -> runREPL ast libraries
-    _ -> do
-      result <- runParserREPL input
-      case result of
-        Left err -> L.printParseError err "REPL" input >> runREPL ast libraries
-        Right (Right toplevel) -> runREPL (ast ++ [toplevel]) libraries
-        Right (Left expression) -> case expression of
-          z@(Let {} C.:>: _) -> runREPL (insertInMain z ast) libraries
-          _ -> do
-            let ast' = insertInMain expression ast
-            anf <- getANFDefinitions input ast' "REPL"
-            case anf of
-              Nothing -> runREPL ast libraries
-              Just anf -> do
-                mapM_ print anf
-                res <- buildAndRun anf libraries []
-                forM_ res putStrLn
-                runREPL ast libraries
+data REPLState = REPLState {
+  ast :: [Located Toplevel],
+  libraries :: [String],
+  flags :: [String],
+  autocompletes :: [String]
+} deriving Show
+
+type REPL a = HaskelineT (StateT REPLState IO) a
+
+eval :: String -> REPL ()
+eval content = do
+  libraries' <- gets libraries
+  flags' <- gets flags
+  result <- liftIO $ runParserREPL content
+  case result of
+    Left err -> liftIO $ L.printParseError err "REPL" content
+    Right (Right toplevel) -> do
+      modify (\s -> s { ast = ast s ++ [toplevel] })
+    Right (Left expression) -> case expression of
+      z@(Let (C.Annoted name _) _ _ C.:>: _) -> ST.modify $ \s -> s { 
+        ast = insertInMain z (ast s),
+        autocompletes = name : autocompletes s }
+      _ -> do
+        ast' <- gets ast
+        let ast'' = insertInMain expression ast'
+        anf <- liftIO $ getANFDefinitions content ast'' "REPL"
+        case anf of
+          Nothing -> return ()
+          Just anf' -> do
+            res <- liftIO $ buildAndRun anf' libraries' flags'
+            liftIO $ forM_ res putStrLn
+
+completion :: (Monad m, MonadState REPLState m) => WordCompleter m
+completion n = do
+  autocompletes' <- gets autocompletes
+  return $ filter (isPrefixOf n) autocompletes'
+
+help :: String -> REPL ()
+help _ = liftIO $ putStrLn "Commands: :help, :quit, :ast, :libraries, :flags, :addLibrary, :addFlag"
+
+addLibrary :: String -> REPL ()
+addLibrary libraries' = do
+  let libraries'' = words libraries'
+  modify (\s -> s { libraries = libraries'' ++ libraries s })
+  liftIO $ putStrLn $ "Added library " ++ unwords libraries''
+
+addFlag :: String -> REPL ()
+addFlag flags' = do
+  let flags'' = words flags'
+  modify (\s -> s { flags = flags'' ++ flags s })
+  liftIO $ putStrLn $ "Added flag " ++ unwords flags''
+
+showLibraries :: REPL ()
+showLibraries = do
+  libraries' <- gets libraries
+  if null libraries'
+    then liftIO $ putStrLn "No libraries"
+    else liftIO $ putStrLn $ "Libraries: " ++ unwords libraries'
+
+showFlags :: REPL ()
+showFlags = do
+  flags' <- gets flags
+  if null flags'
+    then liftIO $ putStrLn "No flags"
+    else liftIO $ putStrLn $ "Flags: " ++ unwords flags'
+
+options' :: [(String, String -> REPL ())]
+options' = [("help", help), ("quit", const abort), ("libraries", const showLibraries), ("flags", const showFlags), ("addLibrary", addLibrary), ("addFlag", addFlag)]
+
+final :: REPL ExitDecision
+final = return Exit
+
+init' :: REPL ()
+init' = do
+  liftIO $ putStrLn "Welcome to Goose REPL"
+  liftIO $ putStrLn "Type :help for help"
+
+inputMode :: MultiLine -> REPL String
+inputMode SingleLine = return "> "
+inputMode MultiLine = return "| "
+
+runREPL :: IO ()
+runREPL = do
+  let initialState = REPLState [] [] [] reservedWords
+  flip evalStateT initialState $ evalRepl inputMode eval options' (Just ':') (Just "multiline") (Word completion) init' final 
 
 insertInMain :: Located Expression -> [Located Toplevel] -> [Located Toplevel]
 insertInMain expression (Function (C.Annoted "main" ty) gens args body C.:>: pos : xs) = do

--- a/src/CLI/REPL.hs
+++ b/src/CLI/REPL.hs
@@ -1,0 +1,51 @@
+module CLI.REPL where
+
+import Language.Goose.Parser.Parser
+import Language.Goose.CST.Expression (Toplevel (Function), Expression (Sequence, Let))
+import Language.Goose.CST.Located (Located)
+import Language.Goose.Parser.Modules.Toplevel (parseToplevel)
+import Language.Goose.Parser.Lexer (parseEither)
+import qualified Text.Parsec as P
+import Text.Parsec (ParseError)
+import System.IO (hFlush, stdout, hSetBuffering, BufferMode (NoBuffering))
+import CLI.Phases (getANFDefinitions)
+import qualified Language.Goose.CST.Located as C
+import qualified Language.Goose.CST.Annoted as C
+import Language.Goose.LLVM.BuildLibrary (buildAndRun)
+import Control.Monad (forM_)
+import qualified Log.Error as L
+
+runParserREPL :: Monad m => String -> m (Either ParseError (Either (Located Expression) (Located Toplevel)))
+runParserREPL input = runGoose "REPL" input $ parseEither (parseExpression <* P.eof) (parseToplevel parseExpression)
+
+runREPL :: [Located Toplevel] -> [String] -> IO ()
+runREPL ast libraries = do
+  hSetBuffering stdout NoBuffering
+  putStr "goose> "
+  input <- getLine
+  case input of
+    ":q" -> return ()
+    [] -> runREPL ast libraries
+    _ -> do
+      result <- runParserREPL input
+      case result of
+        Left err -> L.printParseError err "REPL" input >> runREPL ast libraries
+        Right (Right toplevel) -> runREPL (ast ++ [toplevel]) libraries
+        Right (Left expression) -> case expression of
+          z@(Let {} C.:>: _) -> runREPL (insertInMain z ast) libraries
+          _ -> do
+            let ast' = insertInMain expression ast
+            anf <- getANFDefinitions input ast' "REPL"
+            case anf of
+              Nothing -> runREPL ast libraries
+              Just anf -> do
+                mapM_ print anf
+                res <- buildAndRun anf libraries []
+                forM_ res putStrLn
+                runREPL ast libraries
+
+insertInMain :: Located Expression -> [Located Toplevel] -> [Located Toplevel]
+insertInMain expression (Function (C.Annoted "main" ty) gens args body C.:>: pos : xs) = do
+  Function (C.Annoted "main" ty) gens args (Sequence [body, expression] C.:>: pos) C.:>: pos : xs
+insertInMain expression (x:xs) = x : insertInMain expression xs
+insertInMain expr@(C.Located pos _) [] = [Function (C.Annoted "main" Nothing) [] [] expr C.:>: pos]

--- a/src/Language/Goose/CLang/Compiler.hs
+++ b/src/Language/Goose/CLang/Compiler.hs
@@ -15,8 +15,8 @@ import Data.List
 compileToplevel :: ANFDefinition -> Maybe IRToplevel
 compileToplevel (DFunction name args body) = Just $ IRFunction (varify name) (map varify args) (map compileStatement body)
 compileToplevel (DDeclaration name e) = Just $ IRDeclaration (varify name) (compileExpression e)
-compileToplevel (DDeclare (Annoted name (_ :-> _))) = Just $ IRDeclare (varify name) [rttiName] rttiName
-compileToplevel (DDeclare (Annoted name _)) = Just $ IRDeclare (varify name) [] rttiName
+compileToplevel (DDeclare (Annoted name (_ :-> _))) = Just $ IRDeclare (varify name) (Just [rttiName]) rttiName
+compileToplevel (DDeclare (Annoted name _)) = Just $ IRDeclare (varify name) Nothing rttiName
 from :: Type -> CType
 from _ = rttiName
 
@@ -84,7 +84,7 @@ compileExpression (EMutable e) = IRApplication (IRVariable "create_mutable") [co
 compileExpression (EDereference e) = IRApplication (IRVariable "get_mutable") [compileExpression e]
 
 generateDeclarations :: [String] -> [IRToplevel]
-generateDeclarations = map (\x -> IRDeclare x [rttiName] rttiName)
+generateDeclarations = map (\x -> IRDeclare x (Just [rttiName]) rttiName)
 
 compile :: [ANFDefinition] -> [IRToplevel]
 compile xs = do

--- a/src/Language/Goose/CLang/Definition/Generation.hs
+++ b/src/Language/Goose/CLang/Definition/Generation.hs
@@ -49,8 +49,8 @@ instance Generation IRToplevel where
     fields' <- mapM generate fields
     return $ "struct " ++ varify name ++ " { " ++ unwords fields' ++ " };"
   generate (IRDeclare name args ret) = case args of
-    [] -> return $ ret ++ " " ++ varify name ++ ";"
-    _ -> return $ ret ++ " " ++ varify name ++ "(" ++ intercalate ", " args ++ ");"
+    Nothing -> return $ ret ++ " " ++ varify name ++ ";"
+    Just args -> return $ ret ++ " " ++ varify name ++ "(" ++ intercalate ", " args ++ ");"
   generate (IRGlobalString name str) = return $ "const char*" ++ varify name ++ " = " ++ show str ++ ";"
 
 instance Generation IRStructField where

--- a/src/Language/Goose/CLang/Definition/IR.hs
+++ b/src/Language/Goose/CLang/Definition/IR.hs
@@ -5,7 +5,7 @@ data IRToplevel
   = IRFunction String [String] [IRStatement]
   | IRDeclaration String IRExpression
   | IRExtern String CType
-  | IRDeclare String [CType] CType
+  | IRDeclare String (Maybe [CType]) CType
   | IRStruct String [IRStructField]
   | IRGlobalString String String
   deriving (Eq, Show)

--- a/src/Language/Goose/LLVM/Compiler.hs
+++ b/src/Language/Goose/LLVM/Compiler.hs
@@ -132,12 +132,16 @@ convertToplevel (IR.IRFunction name args body) = do
   return ()
   where args' = [(AST.i64, IRB.ParameterName $ fromString "args")]
 convertToplevel (IR.IRDeclare name args _) = do
-  let argTypes = map (const AST.i64) args
-  let retType = AST.i64
-  let ftype = AST.ptr $ AST.FunctionType retType argTypes False
-  ST.modify . BF.first $ M.insert name $ ConstantOperand $ C.GlobalReference ftype (AST.Name $ fromString name)
-  IRB.extern (AST.Name $ fromString name) [AST.i64] AST.i64
-  return ()
+  case args of
+    Just x -> do
+      let argTypes = map (const AST.i64) x
+      let retType = AST.i64
+      let ftype = AST.ptr $ AST.FunctionType retType argTypes False
+      IRB.extern (AST.Name $ fromString name) [AST.i64] AST.i64
+      ST.modify . BF.first $ M.insert name $ ConstantOperand $ C.GlobalReference ftype (AST.Name $ fromString name)
+    Nothing -> do
+      IRB.global (AST.Name $ fromString name) AST.i64 $ C.Int 64 0
+      ST.modify . BF.first $ M.insert name $ ConstantOperand $ C.GlobalReference (AST.ptr AST.i64) (AST.Name $ fromString name)
 convertToplevel _ = return ()
 
 convertStatement :: LLVM m => IR.IRStatement -> m ()

--- a/src/Language/Goose/Parser/Lexer.hs
+++ b/src/Language/Goose/Parser/Lexer.hs
@@ -8,6 +8,9 @@ import Data.Char
 type Goose m a = Parser m (Located a)
 type Parser m a  = ParsecT String () m a
 
+reservedWords :: [String]
+reservedWords = ["enum", "end", "public", "module", "def", "for", "in", "do", "while", "break", "if", "then", "else", "import", "extern", "return", "declare", "fun", "match", "type", "mutable"]
+
 languageDef :: Monad m => Token.GenLanguageDef String u m
 languageDef =
   Token.LanguageDef {
@@ -20,7 +23,7 @@ languageDef =
             , Token.opLetter        = oneOf ":!#$%&*+./<=>?@\\^|-~"
             , Token.opStart         = Token.opLetter languageDef
             , Token.identLetter     = alphaNum <|> char '_' <|> char '\''
-            , Token.reservedNames   = ["enum", "end", "public", "module", "def", "for", "in", "do", "while", "break", "if", "then", "else", "import", "extern", "return", "declare", "fun", "match", "type", "mutable"]
+            , Token.reservedNames   = reservedWords
             , Token.reservedOpNames = ["(", ")", "*", "+", "-", "/", "{", "}", "[", "]", "<", ">", "=", "->", "::"] }
 
 lexer :: Monad m => Token.GenTokenParser String u m
@@ -85,7 +88,7 @@ lexeme :: Monad m => Parser m a -> Parser m a
 lexeme = Token.lexeme lexer
 
 parseEither :: Goose m a -> Goose m b -> Parser m (Either (Located a) (Located b))
-parseEither pa pb = (Left <$> pa) <|> (Right <$> pb)
+parseEither pa pb = (Left <$> try pa) <|> (Right <$> pb)
 
 lowered :: Monad m => Parser m String
 lowered = lexeme $ do

--- a/src/Language/Goose/Parser/Lexer.hs
+++ b/src/Language/Goose/Parser/Lexer.hs
@@ -84,6 +84,9 @@ decimal = Token.decimal lexer
 lexeme :: Monad m => Parser m a -> Parser m a
 lexeme = Token.lexeme lexer
 
+parseEither :: Goose m a -> Goose m b -> Parser m (Either (Located a) (Located b))
+parseEither pa pb = (Left <$> pa) <|> (Right <$> pb)
+
 lowered :: Monad m => Parser m String
 lowered = lexeme $ do
   c <- lower

--- a/src/Language/Goose/Parser/Parser.hs
+++ b/src/Language/Goose/Parser/Parser.hs
@@ -20,6 +20,9 @@ type SourceFile = String
 parseGoose :: Monad m => SourceFile -> String -> m (Either P.ParseError [C.Located C.Toplevel])
 parseGoose = P.runParserT (L.whiteSpace *> P.many (T.parseToplevel parseExpression) <* P.eof) ()
 
+runGoose :: Monad m => SourceFile -> String -> L.Parser m a -> m (Either P.ParseError a)
+runGoose file src p = P.runParserT (L.whiteSpace *> p <* P.eof) () file src
+
 makeUnaryOp :: Alternative f => f (a -> a) -> f (a -> a)
 makeUnaryOp s = foldr1 (.) . reverse <$> some s
 

--- a/src/Log/Error.hs
+++ b/src/Log/Error.hs
@@ -6,17 +6,19 @@ module Log.Error where
   import Error.Diagnose               ( addFile, printDiagnostic, stderr, defaultStyle, Position (Position), Marker (This), def, stdout, addReport, Report(Err), Note (Note) )
   import Data.Void                    ( Void )
   import Text.Parsec                  ( SourcePos, sourceColumn, sourceLine, sourceName, ParseError )
-  import Data.Maybe                   ( maybeToList )
+  import Data.Maybe                   ( maybeToList, fromJust )
+  import System.Directory (doesFileExist)
   
   instance HasHints Void String where
     hints _ = mempty
 
-  printError :: (String, Maybe String, (SourcePos, SourcePos)) -> String -> IO ()
-  printError (error', msg, (p1, p2)) step = do
+  printError :: Maybe String -> (String, Maybe String, (SourcePos, SourcePos)) -> String -> IO ()
+  printError content (error', msg, (p1, p2)) step = do
     let p1' = (sourceLine p1, sourceColumn p1)
     let p2' = (sourceLine p2, sourceColumn p2)
     let file' = sourceName p1
-    x' <- readFile file'
+    b <- doesFileExist file'
+    x' <- if b then readFile file' else return $ fromJust content
     let pos' = Position p1' p2' $ sourceName p1
     let beautifulExample = Err
           Nothing


### PR DESCRIPTION
Goose does now have a stable CLI interface that will be upgraded in the time. Currently, it supports basic commands such as module execution, compilation and a basic REPL.

All commands are specified when running : `goose` or `goose --help`.

- Compile supports three options which are output file, library including and C module including.
- Running supports library and C module including
- REPL supports in-REPL built-in commands such as library flag adding, C module loading...